### PR TITLE
fix (index): modify var name in line 89

### DIFF
--- a/index.js
+++ b/index.js
@@ -86,7 +86,7 @@
 	    {
 		now_psecs=last_psecs+1;
 		now_secs=last_secs;
-		if (now_usecs===1000000000)
+		if (now_psecs===1000000000)
 		{
 		    now_psecs=now_psecs-1000000000;
 		    now_secs=last_secs+1;


### PR DESCRIPTION
I'm getting an error. It seems there is a typo in var 'now_usecs', it is undefined, please change it to 'now_psecs'